### PR TITLE
drivers/mhz19: Integrated PWM with UART driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -204,9 +204,16 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
-ifneq (,$(filter mhz19,$(USEMODULE)))
+ifneq (,$(filter mhz19_uart,$(USEMODULE)))
   USEMODULE += xtimer
+  USEMODULE += mhz19
   FEATURES_REQUIRED += periph_uart
+endif
+
+ifneq (,$(filter mhz19_pwm,$(USEMODULE)))
+  USEMODULE += xtimer
+  USEMODULE += mhz19
+  FEATURES_REQUIRED += periph_gpio
 endif
 
 ifneq (,$(filter mma8x5x,$(USEMODULE)))

--- a/drivers/include/mhz19.h
+++ b/drivers/include/mhz19.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Koen Zandberg
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,8 +16,8 @@
  * ## Description
  *
  * The MH-Z19 is a C02 sensor. Measurements are provided in ppm over UART and
- * PWM. Only the UART interface is implemented in this driver. PPM range from
- * 0 (theoretically) to 2000 or 5000 depending on the sensor settings.
+ * PWM. PPM range from 0 (theoretically) to 2000 or 5000 depending on the sensor
+ * settings.
  *
  * @note The sensor requires considerable time before accurate measurements are
  * provided
@@ -27,15 +28,23 @@
  * @brief       Interface definition for the mh-z19 CO2 sensor driver.
  *
  * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Christian Manal <manal@uni-bremen.de>
  */
 
 #ifndef MHZ19_H
 #define MHZ19_H
 
-#include "periph/uart.h"
 #include "saul.h"
+
+#ifdef MODULE_MHZ19_UART
+#include "periph/uart.h"
 #include "mhz19_internals.h"
 #include "mutex.h"
+#endif /* MODULE_MHZ19_UART */
+
+#ifdef MODULE_MHZ19_PWM
+#include "periph/gpio.h"
+#endif /* MODULE_MHZ19_PWM */
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,6 +60,7 @@ enum {
     MHZ19_ERR_CHECKSUM  = -3,       /**< checksum failure on received data */
 };
 
+#ifdef MODULE_MHZ19_UART
 /**
  * @brief   Device initialization parameters
  */
@@ -68,6 +78,23 @@ typedef struct {
     uint8_t idx;                    /**< rx buffer index */
     uint8_t rxmem[MHZ19_BUF_SIZE];  /**< rx buffer */
 } mhz19_t;
+#endif /* MODULE_MHZ19_UART */
+
+#ifdef MODULE_MHZ19_PWM
+/**
+ * @brief  Device initialization parameters
+ */
+typedef struct {
+    gpio_t pin;   /**< Pin the sensor is connected to */
+} mhz19_params_t;
+
+/**
+ * @brief  Device descriptor for a mhz19 driver
+ */
+typedef struct {
+    gpio_t pin;   /**< Pin the sensor is connected to */
+} mhz19_t;
+#endif /* MODULE_MHZ19_PWM */
 
 /**
  * @brief   Export SAUL endpoint

--- a/drivers/mhz19/include/mhz19_params.h
+++ b/drivers/mhz19/include/mhz19_params.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Default configuration for MH-Z19
  *
  * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Christian Manal <manal@uni-bremen.de>
  */
 
 #ifndef MHZ19_PARAMS_H
@@ -31,6 +33,7 @@ extern "C" {
  * @name    Set default configuration parameters for the MH-Z19
  * @{
  */
+#ifdef MODULE_MHZ19_UART
 #ifndef MHZ19_PARAM_UART_DEV
 #define MHZ19_PARAM_UART_DEV        UART_DEV(1)
 #endif
@@ -38,6 +41,17 @@ extern "C" {
 #ifndef MHZ19_PARAMS
 #define MHZ19_PARAMS    { .uart = MHZ19_PARAM_UART_DEV }
 #endif
+#endif /* MODULE_MHZ19_UART */
+
+#ifdef MODULE_MHZ19_PWM
+#ifndef MHZ19_PARAM_PIN
+#define MHZ19_PARAM_PIN (GPIO_PIN(0, 0))
+#endif
+
+#ifndef MHZ19_PARAMS
+#define MHZ19_PARAMS    { .pin = MHZ19_PARAM_PIN }
+#endif
+#endif /* MODULE_MHZ19_PWM */
 
 #ifndef MHZ19_SAUL_INFO
 #define MHZ19_SAUL_INFO { .name = "mh-z19" }

--- a/drivers/mhz19/mhz19.c
+++ b/drivers/mhz19/mhz19.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,19 +15,21 @@
  * @brief       Device driver implementation for MH-Z19 CO2 sensor.
  *
  * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Christian Manal <manal@uni-bremen.de>
  *
  * @}
  */
 
 #include "mhz19.h"
-#include "mhz19_internals.h"
 #include "mhz19_params.h"
-#include "periph/uart.h"
 #include "xtimer.h"
 #include "mutex.h"
 
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
+
+#ifdef MODULE_MHZ19_UART
+#include "mhz19_internals.h"
 
 /* Precalculated command sequence */
 static const uint8_t value_read[] = {
@@ -162,3 +165,72 @@ int mhz19_get_ppm(mhz19_t *dev, int16_t *ppm)
 
     return res;
 }
+
+#endif /* MODULE_MHZ19_UART */
+
+#ifdef MODULE_MHZ19_PWM
+
+int mhz19_init(mhz19_t *dev, const mhz19_params_t *params)
+{
+    int16_t res;
+    dev->pin = params->pin;
+    gpio_init(dev->pin, GPIO_IN_PD);
+    /* Take one measurement to make sure there's an mhz19 on the pin */
+    if (mhz19_get_ppm(dev, &res) == MHZ19_ERR_TIMEOUT) {
+        return MHZ19_ERR_TIMEOUT;
+    }
+    return MHZ19_OK;
+}
+
+int mhz19_get_ppm(mhz19_t *dev, int16_t *ppm)
+{
+    uint32_t start, middle, end, th, tl;
+    /*
+     * Per the docs, one sample should take 1004ms +-5%. Worst case is
+     * that  we come in right after the rising edge of the current cycle,
+     * so we wanna wait two cycles plus some wiggle room at most for
+     * a measurement.
+     */
+    int16_t timeout = 2200;
+
+    DEBUG("%s: Waiting for high level to end\n", __func__);
+    while (gpio_read(dev->pin) && timeout) {
+        timeout--;
+        xtimer_usleep(US_PER_MS);
+    }
+
+    DEBUG("%s: Waiting for initial rising edge\n", __func__);
+    while (!gpio_read(dev->pin) && timeout) {
+        timeout--;
+        xtimer_usleep(US_PER_MS);
+    }
+
+    start = xtimer_now_usec() / US_PER_MS;
+    DEBUG("%s: Waiting for falling edge\n", __func__);
+    while (gpio_read(dev->pin) && timeout) {
+        timeout--;
+        xtimer_usleep(US_PER_MS);
+    }
+    middle = xtimer_now_usec() / US_PER_MS;
+    DEBUG("%s: Waiting for rising edge\n", __func__);
+    while (!gpio_read(dev->pin) && timeout) {
+        timeout--;
+        xtimer_usleep(US_PER_MS);
+    }
+
+    /* If we waited too long for flanks, something went wrong */
+    if (!timeout) {
+        DEBUG("%s: Measurement timed out\n", __func__);
+        return MHZ19_ERR_TIMEOUT;
+    }
+    end = xtimer_now_usec() / US_PER_MS;
+
+    th = (middle - start);
+    tl = (end - middle);
+
+    *ppm = (int16_t)(2000 * (th - 2) / (th + tl - 4));
+
+    return MHZ19_OK;
+}
+
+#endif /* MODULE_MHZ19_PWM */

--- a/drivers/mhz19/mhz19_saul.c
+++ b/drivers/mhz19/mhz19_saul.c
@@ -26,7 +26,9 @@ static int read_ppm(const void *dev, phydat_t *res)
     int16_t ppm;
 
     /* Drops the const keyword, otherwise the mutex can't be locked */
-    mhz19_get_ppm((mhz19_t *)dev, &ppm);
+    if (mhz19_get_ppm((mhz19_t *)dev, &ppm) < 0) {
+        return -ECANCELED;
+    }
     res->val[0] = ppm;
     res->unit = UNIT_PPM;
     res->scale = 0;

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -89,6 +89,10 @@ PSEUDOMODULES += adc081c
 PSEUDOMODULES += adc101c
 PSEUDOMODULES += adc121c
 
+# MH-Z19 UART and PWM drivers
+PSEUDOMODULES += mhz19_uart
+PSEUDOMODULES += mhz19_pwm
+
 # include variants of SX127X drivers as pseudo modules
 PSEUDOMODULES += sx1272
 PSEUDOMODULES += sx1276

--- a/tests/driver_mhz19/Makefile
+++ b/tests/driver_mhz19/Makefile
@@ -1,12 +1,15 @@
 include ../Makefile.tests_common
 
-USEMODULE += mhz19
+DRIVER ?= mhz19_uart
+
+USEMODULE += $(DRIVER)
 USEMODULE += xtimer
 
-# set default device parameters in case they are undefined
-TEST_UART ?= 1
-
-# export parameters
-CFLAGS += -DTEST_UART=$(TEST_UART)
+ifneq (,$(filter mhz19_uart,$(USEMODULE)))
+  # set default device parameters in case they are undefined
+  TEST_UART ?= 1
+  # export parameters
+  CFLAGS += -DMHZ19_PARAM_UART_DEV=UART_DEV\($(TEST_UART)\)
+endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mhz19/main.c
+++ b/tests/driver_mhz19/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,28 +15,20 @@
  * @brief       Test application for the MH-Z19 sensor driver
  *
  * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Christian Manal <manal@uni-bremen.de>
  *
  * @}
  */
 
-#ifndef TEST_UART
-#error "TEST_UART not defined"
-#endif
-
 #include <stdio.h>
-
 #include "xtimer.h"
-
-#include "periph/uart.h"
-
 #include "mhz19.h"
+#include "mhz19_params.h"
 
 int main(void)
 {
     mhz19_t dev;
-    mhz19_params_t params = {
-        .uart = TEST_UART,
-    };
+    mhz19_params_t params = MHZ19_PARAMS;
 
     puts("MH-Z19 CO2 sensor test application\n");
 


### PR DESCRIPTION
As suggested [here](https://github.com/RIOT-OS/RIOT/pull/9319#issuecomment-396170241), this is a merge of both our drivers. It adds the mutually exclusive pseudo-modules `mhz19_uart` and `mhz19_pwm` to select which of the two interfaces to use.